### PR TITLE
Add a snap and use Circle CI to build and publish on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: electronuserland/builder
+    steps:
+      - checkout
+      - run:
+          name: "Build"
+          command: |
+            npm i
+            npm run dist-all
+      - run:
+          name: "Publish to Store"
+          command: |
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get -yq install snapcraft
+            mkdir .snapcraft
+            echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
+            snapcraft push dist/*.snap --release stable
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/

--- a/package.json
+++ b/package.json
@@ -62,7 +62,11 @@
         "Name": "PanWriter",
         "Comment": "Markdown editor with pandoc integration and paginated preview"
       },
-      "category": "Utility"
+      "category": "Utility",
+      "target": [
+        "snap",
+        "AppImage"
+      ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #7. I've tested that the snap builds fine. I've lint'ed the circleci config and written it to the best of my understanding to only fire for tags, but I don't have the ability to test this myself. We'll just have to land on master, optionally disable the tag filter, and push a commit to test.