### PR TITLE
Add missing call to `npm run build` in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
           name: "Build"
           command: |
             npm i
+            npm run build
             npm run dist -- -l --publish=never
       - run:
           name: "Publish to Store"


### PR DESCRIPTION
I just discovered that I missed a call to `npm run build` in Circle CI. Sorry about that!