### PR TITLE
Fix undefined error during export

### DIFF
--- a/src/js/Exporter.js
+++ b/src/js/Exporter.js
@@ -102,7 +102,7 @@ function mergeAndValidate(docMeta, extMeta, outputPath) {
     toFormat = 'latex'
   }
 
-  const extractOut = meta => (meta.output && typeof meta.output === 'object')
+  const extractOut = meta => (meta && meta.output && typeof meta.output === 'object')
                                ? meta.output[toFormat]
                                : {}
                                ;


### PR DESCRIPTION
Now sometimes (for some documents) during export Uncaught undefined is thrown:
```
C:\Program Files\PanWriter\resources\app.asar\src\js\Exporter.js:105 Uncaught (in promise) TypeError: Cannot read property 'output' of undefined
    at extractOut (C:\Program Files\PanWriter\resources\app.asar\src\js\Exporter.js:105)
    at mergeAndValidate (C:\Program Files\PanWriter\resources\app.asar\src\js\Exporter.js:109)
    at fileExport (C:\Program Files\PanWriter\resources\app.asar\src\js\Exporter.js:59)
```

this PR fix it. Thank you.