### PR TITLE
Fix export pdf error, empty external yaml

### DIFF
--- a/src/js/Exporter.js
+++ b/src/js/Exporter.js
@@ -128,7 +128,7 @@ function mergeAndValidate(docMeta, extMeta, outputPath) {
 async function defaultMeta(type) {
   try {
     const [str, fileName] = await readDataDirFile(type, '.yaml');
-    return [ jsYaml.safeLoad(str), ['--metadata-file', fileName] ]
+    return [ jsYaml.safeLoad(str) || {}, ['--metadata-file', fileName] ]
   } catch(e) {
     console.warn("Error loading or parsing YAML file." + e.message);
     return [ {}, [] ];


### PR DESCRIPTION
Hi, we battle tested export ;) and i found some other edge case:
when you have empty default.yaml file and export to pdf format. 
```
Uncaught (in promise) TypeError: Cannot read property 'pdf-format' of undefined
    at mergeAndValidate (C:\Program Files\PanWriter\resources\app.asar\src\js\Exporter.js:100)
    at fileExport (C:\Program Files\PanWriter\resources\app.asar\src\js\Exporter.js:59)
```
my PR fix it, we tested it.
Btw i think we need to write some tests and run them with each change. I think i can write them when I have more time..