### PR TITLE
Add settings.yaml config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,10 @@ If the directory does not exist, you can create it.
 
 ### Settings
 
-If you put a `settings.yaml` file in the data directory, PanWriter will read it on startup. Possible fields are:
+If you put a `settings.yaml` file in the data directory, PanWriter will read it on startup. Possible fields are currently only:
 
 ```yaml
 autoUpdateApp: true
-editorIncludes:  |-
-  <style>
-  body {
-    font-family: Arial;
-  }
-  </style>
 ```
 
 ### Default CSS and YAML

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ editorIncludes:  |-
     font-family: Arial;
   }
   </style>
-pandocExecPath: '/usr/bin/'
 ```
 
 ### Default CSS and YAML

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ You can place certain files in the PanWriter user directory, which [should be](h
 
 If the directory does not exist, you can create it.
 
+### Settings
+
+If you put a `settings.yaml` file in the data directory, PanWriter will read it on startup. Possible fields are:
+
+```yaml
+autoUpdateApp: true
+editorIncludes:  |-
+  <style>
+  body {
+    font-family: Arial;
+  }
+  </style>
+pandocExecPath: '/usr/bin/'
+```
+
 ### Default CSS and YAML
 
 If you put a `default.yaml` file in the data directory, PanWriter will merge this with the YAML in your input file (to determine the command-line arguments to call pandoc with) and add the `--metadata-file` option. The YAML should be in the same format as above.

--- a/electron/dataDir.ts
+++ b/electron/dataDir.ts
@@ -8,6 +8,7 @@ export const dataDir = [app.getPath('appData'), 'PanWriterUserData', ''].join(se
 
 /**
  * reads the right default yaml file
+ *
  * make sure this function is safe to expose in `preload.ts`
  */
 export const readDataDirFile = async (fileName: string): Promise<[Meta | undefined, string]> => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import { AppState, Doc, Meta, ViewSplit } from '../src/appState/AppState'
+import { AppState, Doc, Meta, Settings, ViewSplit } from '../src/appState/AppState'
 import { Action } from '../src/appState/Action'
 
 export type IpcApi = typeof ipcApi
@@ -17,6 +17,11 @@ ipcRenderer.on('getDoc', (_e, replyChannel: string) => {
 export type Message = {
   type: 'initDoc';
   doc: Pick<Doc, 'md' | 'fileName' | 'filePath' | 'fileDirty'>;
+  settings: Settings;
+}
+| {
+  type: 'loadSettings';
+  settings: Settings;
 }
 | {
   type: 'split';

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -1,0 +1,16 @@
+import { Settings } from '../src/appState/AppState'
+import { readDataDirFile } from './dataDir'
+
+export const loadSettings = async (): Promise<Settings> => {
+  const [data] = await readDataDirFile('settings.yaml')
+  return parseSettings(data)
+}
+
+const parseSettings = (data: Record<string, unknown> = {}): Settings => {
+  const { autoUpdateApp, editorIncludes, pandocExecPath } = data
+  return {
+    autoUpdateApp: autoUpdateApp === undefined ? true : !!autoUpdateApp,
+    editorIncludes: typeof editorIncludes === 'string' ? editorIncludes : undefined,
+    pandocExecPath: typeof pandocExecPath === 'string' ? pandocExecPath : ''
+  }
+}

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -7,9 +7,8 @@ export const loadSettings = async (): Promise<Settings> => {
 }
 
 const parseSettings = (data: Record<string, unknown> = {}): Settings => {
-  const { autoUpdateApp, editorIncludes } = data
+  const { autoUpdateApp } = data
   return {
-    autoUpdateApp: autoUpdateApp === undefined ? defaultSettings.autoUpdateApp : !!autoUpdateApp,
-    editorIncludes: typeof editorIncludes === 'string' ? editorIncludes : defaultSettings.editorIncludes
+    autoUpdateApp: autoUpdateApp === undefined ? defaultSettings.autoUpdateApp : !!autoUpdateApp
   }
 }

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -7,10 +7,9 @@ export const loadSettings = async (): Promise<Settings> => {
 }
 
 const parseSettings = (data: Record<string, unknown> = {}): Settings => {
-  const { autoUpdateApp, editorIncludes, pandocExecPath } = data
+  const { autoUpdateApp, editorIncludes } = data
   return {
     autoUpdateApp: autoUpdateApp === undefined ? defaultSettings.autoUpdateApp : !!autoUpdateApp,
-    editorIncludes: typeof editorIncludes === 'string' ? editorIncludes : defaultSettings.editorIncludes,
-    pandocExecPath: typeof pandocExecPath === 'string' ? pandocExecPath : defaultSettings.pandocExecPath
+    editorIncludes: typeof editorIncludes === 'string' ? editorIncludes : defaultSettings.editorIncludes
   }
 }

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -1,4 +1,4 @@
-import { Settings } from '../src/appState/AppState'
+import { defaultSettings, Settings } from '../src/appState/AppState'
 import { readDataDirFile } from './dataDir'
 
 export const loadSettings = async (): Promise<Settings> => {
@@ -9,8 +9,8 @@ export const loadSettings = async (): Promise<Settings> => {
 const parseSettings = (data: Record<string, unknown> = {}): Settings => {
   const { autoUpdateApp, editorIncludes, pandocExecPath } = data
   return {
-    autoUpdateApp: autoUpdateApp === undefined ? true : !!autoUpdateApp,
-    editorIncludes: typeof editorIncludes === 'string' ? editorIncludes : undefined,
-    pandocExecPath: typeof pandocExecPath === 'string' ? pandocExecPath : ''
+    autoUpdateApp: autoUpdateApp === undefined ? defaultSettings.autoUpdateApp : !!autoUpdateApp,
+    editorIncludes: typeof editorIncludes === 'string' ? editorIncludes : defaultSettings.editorIncludes,
+    pandocExecPath: typeof pandocExecPath === 'string' ? pandocExecPath : defaultSettings.pandocExecPath
   }
 }

--- a/src/appState/Action.ts
+++ b/src/appState/Action.ts
@@ -1,4 +1,4 @@
-import { Doc, ViewSplit } from '../appState/AppState'
+import { Doc, Settings, ViewSplit } from '../appState/AppState'
 
 export type Action = {
   type: 'closeMetaEditorAndSetMd';
@@ -6,6 +6,11 @@ export type Action = {
 | {
   type: 'initDoc';
   doc: Pick<Doc, 'md' | 'fileName' | 'filePath' | 'fileDirty'>;
+  settings: Settings;
+}
+| {
+  type: 'loadSettings';
+  settings: Settings;
 }
 | {
   type: 'setMdAndRender';

--- a/src/appState/AppState.ts
+++ b/src/appState/AppState.ts
@@ -38,7 +38,6 @@ export type ViewSplit = typeof viewSplits[number]
 
 export interface Settings {
   autoUpdateApp: boolean;
-  editorIncludes?: string;
 }
 
 export const defaultSettings: Settings = {

--- a/src/appState/AppState.ts
+++ b/src/appState/AppState.ts
@@ -41,3 +41,8 @@ export interface Settings {
   editorIncludes?: string;
   pandocExecPath: string;
 }
+
+export const defaultSettings: Settings = {
+  autoUpdateApp: true,
+  pandocExecPath: ''
+}

--- a/src/appState/AppState.ts
+++ b/src/appState/AppState.ts
@@ -3,6 +3,7 @@ import { RefObject } from 'react'
 export interface AppState {
   doc: Doc;
   metaEditorOpen: boolean;
+  settings: Settings
   split: ViewSplit;
   paginated: boolean;
   previewDivRef: RefObject<HTMLDivElement>;
@@ -34,3 +35,9 @@ export type JSON = string | number | boolean | null | Meta[] | { [key: string]: 
 
 export const viewSplits = ['onlyEditor', 'split', 'onlyPreview'] as const
 export type ViewSplit = typeof viewSplits[number]
+
+export interface Settings {
+  autoUpdateApp: boolean;
+  editorIncludes?: string;
+  pandocExecPath: string;
+}

--- a/src/appState/AppState.ts
+++ b/src/appState/AppState.ts
@@ -39,10 +39,8 @@ export type ViewSplit = typeof viewSplits[number]
 export interface Settings {
   autoUpdateApp: boolean;
   editorIncludes?: string;
-  pandocExecPath: string;
 }
 
 export const defaultSettings: Settings = {
-  autoUpdateApp: true,
-  pandocExecPath: ''
+  autoUpdateApp: true
 }

--- a/src/appState/appStateReducer.ts
+++ b/src/appState/appStateReducer.ts
@@ -15,9 +15,14 @@ export const appStateReducer = (state: AppState, action: Action): AppState => {
       return { ...state, doc }
     }
     case 'initDoc': {
+      const { settings } = action
       const { md } = action.doc
       const doc = { ...state.doc, ...action.doc, ...parseYaml(md) }
-      return { ...state, doc }
+      return { ...state, doc, settings }
+    }
+    case 'loadSettings': {
+      const { settings } = action
+      return { ...state, settings }
     }
     case 'setMdAndRender': {
       const { md } = action

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import { createRef, useEffect, useReducer } from 'react'
 
-import { AppState }     from '../../appState/AppState'
+import { defaultSettings, AppState }     from '../../appState/AppState'
 import { appStateReducer }  from '../../appState/appStateReducer'
 
 import { Editor }       from '../Editor/Editor'

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -68,6 +68,7 @@ const initialState: AppState = {
   , fileDirty: false
   }
 , metaEditorOpen: false
+, settings: defaultSettings
 , split: 'onlyEditor'
 , paginated: false
 , previewDivRef: createRef()


### PR DESCRIPTION
implements https://github.com/mb21/panwriter/issues/93https://github.com/mb21/panwriter/issues/93

in the process I decided for now to:

* remove setting.pandocExecPath for now

   because it's tricky to get this right without compromising security: e.g if we read it directly from the AppState, can arbitrary code in electron renderer process set it to an arbitrary path?

* remove editorIncludes or editorStyles fields

   because I'm having seconds thoughts about injecting arbitrary JS or even CSS. We cannot even limit the CSS's scope to .react-codemirror2 without parsing it. I remember having read that VScode chose not to do this after having learnt from Atom's mistakes there.