### PR TITLE
Fix: Add Minimum Width & Height to Window

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -33,6 +33,8 @@ ipc.init()
 const createWindow = async (filePath?: string, toImport=false, wasCreatedOnStartup=false) => {
   const win: CustomBrowserWindow = new BrowserWindow({
       width: 1000
+    , minWidth: 500
+    , minHeight: 400
     , height: 800
     , frame: process.platform !== 'darwin'
     , show: false


### PR DESCRIPTION
Allows window to have a minimum width and height instead of shrinking all in as shows below.
![panwriter](https://user-images.githubusercontent.com/87912847/209489306-968a2cb0-9257-4ccd-86d5-c7921bad52fd.jpeg)
