### PR TITLE
Enable mainfont in default.yaml

### DIFF
--- a/electron/pandoc/export.ts
+++ b/electron/pandoc/export.ts
@@ -226,7 +226,7 @@ const mergeAndValidate = (docMeta: Meta, extMeta: Meta, outputPath?: string, toC
     out.metadata = {};
   }
   if (docMeta.mainfont === undefined) {
-    out.metadata.mainfont = '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif';
+    out.metadata.mainfont = extMeta.mainfont || '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif';
   }
   if (docMeta.monobackgroundcolor === undefined) {
     out.metadata.monobackgroundcolor = '#f0f0f0';

--- a/electron/pandoc/export.ts
+++ b/electron/pandoc/export.ts
@@ -225,11 +225,13 @@ const mergeAndValidate = (docMeta: Meta, extMeta: Meta, outputPath?: string, toC
   if (typeof out.metadata !== 'object') {
     out.metadata = {};
   }
-  if (docMeta.mainfont === undefined) {
-    out.metadata.mainfont = extMeta.mainfont || '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif';
-  }
-  if (docMeta.monobackgroundcolor === undefined) {
-    out.metadata.monobackgroundcolor = '#f0f0f0';
+  if (toFormat === 'html') {
+    if (docMeta.mainfont === undefined) {
+      out.metadata.mainfont = '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif';
+    }
+    if (docMeta.monobackgroundcolor === undefined) {
+      out.metadata.monobackgroundcolor = '#f0f0f0';
+    }
   }
 
   if (outputPath) {


### PR DESCRIPTION
This change allows the main font to be set via `default.yaml` as proposed in #131 