### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,6 @@
-FROM debian
+FROM electronuserland/builder
 
 WORKDIR /home/panwriter
-
-RUN apt-get update -y \
- && apt-get install -y \
-    git \
-    curl \
-    gnupg2 \
-;
-# We seem to require the newest nodejs
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-# Also a newer yarn is required
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
- && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-# Install it
-RUN apt-get update -y  \
- && apt-get install -y \
-    yarn
 
 COPY ./ ./
 # And prepare

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian
+
+WORKDIR /home/panwriter
+
+RUN apt-get update -y \
+ && apt-get install -y \
+    git \
+    curl \
+    gnupg2 \
+;
+# We seem to require the newest nodejs
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+# Also a newer yarn is required
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+# Install it
+RUN apt-get update -y  \
+ && apt-get install -y \
+    yarn
+
+COPY ./ ./
+# And prepare
+RUN yarn \
+ && yarn install
+
+# Remove src and electron
+# they should be bound to the host directories
+# see docker-compose.yaml
+RUN rm -rf src electron

--- a/README.md
+++ b/README.md
@@ -34,6 +34,44 @@ Install git and [yarn](https://yarnpkg.com/), then:
 
 Check out the `package.json` for more scripts to run.
 
+### Using Docker Compose
+
+Install Docker and Docker Compose for your system, then:
+
+    git clone git@github.com:mb21/panwriter.git
+    cd panwriter
+    docker compose build
+    mkdir dist
+
+This will prepare a docker image, which can be used for development.
+
+#### Start an interactive bash shell
+
+    docker compose run --rm -it panwriter
+
+The directories
+
+- `src`
+- `electron`
+- `dist`
+
+are bound into the container.
+So any change you make to the source with your preferred editor
+will be available in the container where you then can run the
+development server or build the application.
+
+#### useful commands
+
+Build for
+
+    docker compose run panwriter yarn dist        # Linux
+    docker compose run panwriter yarn dist -w     # Windows
+    docker compose run panwriter yarn dist -m zip # Mac OS
+
+Start development server
+
+    docker compose up panserver
+
 ### TODOs
 
 - Preview:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: "3.5"
+
+x-default: &defaults
+  image: panwriter:0.8.5
+  volumes:
+    - type: bind
+      source: src
+      target: /home/panwriter/src
+    - type: bind
+      source: electron
+      target: /home/panwriter/electron
+    - type: bind
+      source: dist
+      target: /home/panwriter/dist
+
+services:
+  panwriter:
+    <<: *defaults
+    build:
+      context: .
+    restart: "never"
+    command: [ /bin/bash ]
+    tty: true
+
+  panserver:
+    <<: *defaults
+    restart: "unless-stopped"
+    command: [ yarn, electron:dev ]
+    ports:
+      - target: 3000
+        published: 3000
+        protocol: tcp
+        mode: host


### PR DESCRIPTION
This will allow others to develop for panwriter by using docker.

The advantage is that no one needs to polute their development machine with installation of all the requirements.