### PR TITLE
Add LaTeX delimiters configuration option

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -70,9 +70,17 @@ If the directory does not exist, you can create it.
 
 ## Settings
 
-If you put a `settings.yaml` file in the data directory, PanWriter will read it on startup. Possible fields are currently only:
+If you put a `settings.yaml` file in the data directory, PanWriter will read it on startup. Available settings are:
 
+    # Whether to automatically check for and install app updates
     autoUpdateApp: true
+
+    # Configure which LaTeX math delimiters to use
+    # Can be a single value or an array of values
+    # See https://github.com/goessner/markdown-it-texmath/blob/master/readme.md for all options
+    latexDelimiters: 
+      - dollars   # Use $...$ for inline and $$...$$ for block math
+      - brackets  # Use \(...\) for inline and \[...\] for block math
 
 ## Default CSS and YAML
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -84,6 +84,10 @@ const createWindow = async (filePath?: string, toImport=false, wasCreatedOnStart
     } else {
       ipc.sendMessage(win, { type: 'loadSettings', settings })
     }
+  } else {
+    const settings = await settingsPromise
+    await windowReady
+    ipc.sendMessage(win, { type: 'loadSettings', settings })
   }
   await windowReady
   ipc.sendPlatform(win)

--- a/electron/settings.ts
+++ b/electron/settings.ts
@@ -7,8 +7,9 @@ export const loadSettings = async (): Promise<Settings> => {
 }
 
 const parseSettings = (data: Record<string, unknown> = {}): Settings => {
-  const { autoUpdateApp } = data
+  const { autoUpdateApp, latexDelimiters } = data
   return {
-    autoUpdateApp: autoUpdateApp === undefined ? defaultSettings.autoUpdateApp : !!autoUpdateApp
+    autoUpdateApp: autoUpdateApp === undefined ? defaultSettings.autoUpdateApp : !!autoUpdateApp,
+    latexDelimiters: latexDelimiters === undefined ? defaultSettings.latexDelimiters : latexDelimiters as Settings['latexDelimiters']
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panwriter",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panwriter",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "hasInstallScript": true,
       "dependencies": {
         "codemirror": "^5.61.0",
@@ -26,7 +26,7 @@
         "markdown-it-sub": "^1.0.0",
         "markdown-it-sup": "^1.0.0",
         "markdown-it-task-lists": "^2.1.1",
-        "markdown-it-texmath": "^0.8.0",
+        "markdown-it-texmath": "^1.0.0",
         "pagedjs": "0.1.43",
         "react": "^18.2.0",
         "react-codemirror2": "^7.2.1",
@@ -4530,73 +4530,6 @@
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true
     },
-    "node_modules/archiver": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
-      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.4",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -5966,22 +5899,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/compress-commons": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
-      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "license": "MIT",
@@ -6305,33 +6222,6 @@
       "optional": true,
       "dependencies": {
         "buffer": "^5.1.0"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
-      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/cross-spawn": {
@@ -7269,19 +7159,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows": {
-      "version": "25.1.8",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz",
-      "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "app-builder-lib": "25.1.8",
-        "archiver": "^5.3.1",
-        "builder-util": "25.1.7",
-        "fs-extra": "^10.1.0"
       }
     },
     "node_modules/electron-builder/node_modules/cliui": {
@@ -9000,13 +8877,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -11379,45 +11249,6 @@
       "version": "1.0.5",
       "license": "MIT"
     },
-    "node_modules/lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "license": "MIT",
@@ -11499,41 +11330,13 @@
       "version": "4.0.8",
       "license": "MIT"
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
       "license": "MIT"
     },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -11546,13 +11349,6 @@
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "license": "MIT"
-    },
-    "node_modules/lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -11766,8 +11562,9 @@
       "license": "ISC"
     },
     "node_modules/markdown-it-texmath": {
-      "version": "0.8.0",
-      "license": "MIT"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-texmath/-/markdown-it-texmath-1.0.0.tgz",
+      "integrity": "sha512-4hhkiX8/gus+6e53PLCUmUrsa6ZWGgJW2XCW6O0ASvZUiezIK900ZicinTDtG3kAO2kon7oUA/ReWmpW2FByxg=="
     },
     "node_modules/matcher": {
       "version": "3.0.0",
@@ -14576,29 +14373,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "license": "MIT",
@@ -16314,23 +16088,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -16697,18 +16454,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "2.19.0",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -16789,6 +16534,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17916,43 +17662,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
-      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "archiver-utils": "^3.0.4",
-        "compress-commons": "^4.1.2",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/zip-stream/node_modules/archiver-utils": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
-      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.2.3",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
     "markdown-it-task-lists": "^2.1.1",
-    "markdown-it-texmath": "^0.8.0",
+    "markdown-it-texmath": "^1.0.0",
     "pagedjs": "0.1.43",
     "react": "^18.2.0",
     "react-codemirror2": "^7.2.1",

--- a/src/appState/AppState.ts
+++ b/src/appState/AppState.ts
@@ -38,8 +38,11 @@ export type ViewSplit = typeof viewSplits[number]
 
 export interface Settings {
   autoUpdateApp: boolean;
+  latexDelimiters?: 'dollars' | 'brackets' | 'doxygen' | 'gitlab' | 'julia' | 'kramdown' | 'beg_end' | 
+    ('dollars' | 'brackets' | 'doxygen' | 'gitlab' | 'julia' | 'kramdown' | 'beg_end')[];
 }
 
 export const defaultSettings: Settings = {
-  autoUpdateApp: true
+  autoUpdateApp: true,
+  latexDelimiters: 'dollars'
 }

--- a/src/appState/appStateReducer.ts
+++ b/src/appState/appStateReducer.ts
@@ -2,6 +2,7 @@ import { AppState } from './AppState'
 import { clearPreview, refreshEditor } from '../renderPreview/scrolling'
 import { parseYaml, serializeMetaToMd } from '../renderPreview/convertYaml'
 import { Action } from './Action'
+import { configureMarkdownIt } from '../renderPreview/convertMd'
 
 
 export const appStateReducer = (state: AppState, action: Action): AppState => {
@@ -16,12 +17,14 @@ export const appStateReducer = (state: AppState, action: Action): AppState => {
     }
     case 'initDoc': {
       const { settings } = action
+      configureMarkdownIt(settings)
       const { md } = action.doc
       const doc = { ...state.doc, ...action.doc, ...parseYaml(md) }
       return { ...state, doc, settings }
     }
     case 'loadSettings': {
       const { settings } = action
+      configureMarkdownIt(settings)
       return { ...state, settings }
     }
     case 'setMdAndRender': {

--- a/src/renderPreview/convertMd.ts
+++ b/src/renderPreview/convertMd.ts
@@ -3,17 +3,24 @@ import Renderer from 'markdown-it/lib/renderer'
 import markdownItPandoc from 'markdown-it-pandoc'
 import texmath from 'markdown-it-texmath'
 import katex from 'katex'
-import { Doc } from '../appState/AppState'
+import { Doc, Settings } from '../appState/AppState'
 
-// Configure markdown-it-texmath delimiters to support both dollars and brackets
+// Initialize markdown-it instance
 const md = markdownIt()
-md.use(texmath, { 
-  engine: katex,
-  // Use brackets mode for \( \) and \[ \] support and dollars for $...$ and $$...$$ support
-  delimiters: ['brackets', 'dollars']
-})
-const mdItPandoc = markdownItPandoc(md)
-const defaultImageRender = mdItPandoc.renderer.rules.image
+let mdItPandoc = markdownItPandoc(md)
+let defaultImageRender = mdItPandoc.renderer.rules.image as Renderer.RenderRule
+
+/**
+ * Configure markdown-it with the provided settings
+ */
+export const configureMarkdownIt = (settings: Settings) => {
+  md.use(texmath, { 
+    engine: katex,
+    delimiters: settings.latexDelimiters
+  })
+  mdItPandoc = markdownItPandoc(md)
+  defaultImageRender = mdItPandoc.renderer.rules.image as Renderer.RenderRule
+}
 
 /**
  * converts the markdown in `doc` to HTML

--- a/src/renderPreview/convertMd.ts
+++ b/src/renderPreview/convertMd.ts
@@ -1,9 +1,18 @@
 import markdownIt, { Options } from 'markdown-it'
 import Renderer from 'markdown-it/lib/renderer'
 import markdownItPandoc from 'markdown-it-pandoc'
+import texmath from 'markdown-it-texmath'
+import katex from 'katex'
 import { Doc } from '../appState/AppState'
 
-const mdItPandoc = markdownItPandoc(markdownIt())
+// Configure markdown-it-texmath delimiters to support both dollars and brackets
+const md = markdownIt()
+md.use(texmath, { 
+  engine: katex,
+  // Use brackets mode for \( \) and \[ \] support and dollars for $...$ and $$...$$ support
+  delimiters: ['brackets', 'dollars']
+})
+const mdItPandoc = markdownItPandoc(md)
 const defaultImageRender = mdItPandoc.renderer.rules.image
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,20 @@
+declare module 'markdown-it-texmath' {
+  import { PluginWithOptions } from 'markdown-it'
+  
+  interface TexmathOptions {
+    engine: any;
+    delimiters: string | Array<{
+      name: string;
+      inline: [string, string];
+      display: [string, string];
+    }>;
+  }
+
+  const texmath: PluginWithOptions<TexmathOptions>
+  export default texmath
+}
+
+declare module 'katex' {
+  const katex: any
+  export default katex
+} 


### PR DESCRIPTION
I do lots of LLM training in advanced math domains and as part of that work I have to write documents that are Markdown with embedded LaTeX (math) similar to what ChatGPT produces as output. PanWriter is great for this except that I need it to support brackets like \(...\) and \[...\] for delimiting LaTeX in addition to $...$ and $$...$$.

As of version 1.0.0 the `markdown-it-texmath` library can be configured with a `delimiters` option that can be `'dollars'` (the default which PanWriter has been using) or `'brackets'` or various other options, _including_ any combination of them like `['dollars', 'brackets']`.

This PR adds support to the PanWriter `settings.yaml` file for a new option `latexDelimiters` which mirrors those same `markdown-it-texmath` `delimiters` options.

Specifically:
- Added latexDelimiters setting to configure LaTeX math delimiters
- Updated MANUAL.md with documentation and examples
- Tested support for dollars and brackets delimiters extensively

(Note that I wanted to fork and implement this for my own use no matter what, but I implemented it as a config option - where the default is still only `dollars` so that it could potentially be merged upstream experimentally. I didn't investigate deeply to see if \(...\) or \[...\] would conflict with other Markdown syntax.)