### PR TITLE
Fix markdown bullet list export by specifying GFM input format

### DIFF
--- a/electron/pandoc/export.ts
+++ b/electron/pandoc/export.ts
@@ -137,7 +137,11 @@ const runFileExport = async (
   const out = mergeAndValidate(docMeta, extMeta || {}, exp.outputPath, exp.toClipboardFormat)
 
   const cmd  = 'pandoc'
-  const args = (extMeta ? ['--metadata-file', fileName] : []).concat( toArgs(out) )
+  // Use GFM (GitHub Flavored Markdown) as input format
+  // GFM allows bullet lists without blank lines before them, matching how markdown-it renders in preview
+  // This fixes the issue where lists weren't being recognized in exported documents
+  const fromFormat = 'gfm'
+  const args = ['-f', fromFormat].concat(extMeta ? ['--metadata-file', fileName] : []).concat( toArgs(out) )
   const cmdDebug = cmd + ' ' + args.map(a => a.includes(' ') ? `'${a}'` : a).join(' ')
   let receivedError = false
 


### PR DESCRIPTION
Bullet lists were not rendering correctly in exported .docx and .html files. Lists would collapse into single paragraphs instead of maintaining their structure.

Root cause: Pandoc was using strict CommonMark format which requires blank lines before lists. However, many markdown files have lists immediately after text without spacing (e.g., after colons), which is valid in GitHub Flavored Markdown and markdown-it (the preview renderer).

Solution: Specify 'gfm' (GitHub Flavored Markdown) as the input format when calling pandoc. This ensures consistency between preview rendering and export output, so what you see in the preview matches what gets exported.

This change affects all export formats (.docx, .html, .pdf, etc.) and makes the export behavior match the preview behavior for bullet lists.